### PR TITLE
Hotfix: bazel sync fails when skipping platforms

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,4 +3,5 @@ package(default_visibility = ["//visibility:public"])
 exports_files([
     "pkg_config.bzl",
     "BUILD.tmpl",
+    "BUILD.empty.tmpl",
 ])

--- a/BUILD.empty.tmpl
+++ b/BUILD.empty.tmpl
@@ -1,0 +1,14 @@
+# vi: ft=bzl
+# Skipped on platform %{platform} by rule configuration
+
+filegroup(
+    name = "internal_lib",
+    srcs = [],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "lib",
+    srcs = [],
+    visibility = ["//visibility:public"],
+)

--- a/BUILD.empty.tmpl
+++ b/BUILD.empty.tmpl
@@ -1,14 +1,15 @@
 # vi: ft=bzl
 # Skipped on platform %{platform} by rule configuration
 
-filegroup(
-    name = "internal_lib",
+cc_library(
+    name = "lib",
     srcs = [],
+    hdrs = [],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
-    name = "lib",
+cc_library(
+    name = "internal_lib",
     srcs = [],
     visibility = ["//visibility:public"],
 )

--- a/pkg_config.bzl
+++ b/pkg_config.bzl
@@ -137,7 +137,9 @@ def _pkg_config_impl(ctx):
     os_name = _get_current_platform(ctx)
     pkg_name = ctx.attr.pkg_name
     if os_name in ctx.attr.skip_platforms:
-        ctx.file("BUILD", "# Skipped on platform {} by rule configuration".format(os_name))
+        ctx.template("BUILD", Label("//:BUILD.empty.tmpl"), substitutions = {
+            "%{platform}": os_name,
+        }, executable = False)
         # If we should not build on current platform, then the procedure finishes here.
         # We would consider this as successful.
         message_string = "Local lib '{}' skipped on platform {} by rule configuration".format(pkg_name, os_name)


### PR DESCRIPTION
When current platform is being skipped, bazel build/run will pass normally. However, `bazel sync` will fail because the dependency repo `lib` is not found. 

This PR introduces a fix for that.